### PR TITLE
Use math/ceil to approximate dates to give conservative estimate

### DIFF
--- a/diff.janet
+++ b/diff.janet
@@ -13,7 +13,7 @@
   [date1 date2 &opt unit]
   (default unit :seconds)
   (let [sec-diff (- (epoch/date->timestamp date2) (epoch/date->timestamp date1))]
-    (math/round
+    (math/ceil
       (/ sec-diff
          (case unit
            :seconds 1


### PR DESCRIPTION
E.g. 7.1 days away means the date still hasn't arrived in 7 days - math/round was flipping the date after half a day. This seems better.